### PR TITLE
Preserve URL query params when proxying requests

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -78,6 +78,11 @@ export async function createServer(opts: ServerOpts) {
 				requestLogger.debug("Handling request");
 
 				const url = new URL(`${opts.server}/${ctx.params["*"]}`);
+				// Preserve original query parameters
+				Object.entries(ctx.query).forEach(([key, value]) => {
+					url.searchParams.set(key, value);
+				});
+
 				requestLogger.silly(`URL: ${url.toString()}`);
 
 				const headers = new Headers(ctx.request.headers);


### PR DESCRIPTION
## Explanation of Changes

An RPC query using URL parameter such as https://rpc.testnet.seda.xyz/block?height=5814859 is not working because the URL reconstruction does not include query parameters.

## Testing

Tested in local setup.