### PR TITLE
Disable websocket

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/cosmos-accelerator",
 	"private": true,
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"type": "module",
 	"main": "./src/index.ts",
 	"dependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"private": true,
 	"main": "./src/index.ts",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"dependencies": {
 		"@seda-protocol/cosmos-accelerator-logger": "workspace:*",
 		"@seda-protocol/utils": "catalog:",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -69,6 +69,16 @@ export async function createServer(opts: ServerOpts) {
 				},
 			});
 		})
+		.get("/websocket", async (ctx) => {
+			const requestLogger = logger.child({
+				id: `websocket-request-${ctx.requestId}`,
+			});
+			requestLogger.debug("Handling request");
+
+			return new Response("WebSocket not supported", {
+				status: 501,
+			});
+		})
 		.all(
 			"/*",
 			async (ctx) => {


### PR DESCRIPTION
## Motivation

The websocket endpoint hasn't worked as it opens a socket between the accelerator and the `sedad` node, not the requesting client and the node. We might as well be explicit and not consume the resources needlessly.

## Explanation of Changes

N.A.

## Testing

N.A.

## Related PRs and Issues

N.A.
